### PR TITLE
#5 [SETTING] 카프카 설정

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation "org.springframework.kafka:spring-kafka"
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/chat/docker-compose.yml
+++ b/chat/docker-compose.yml
@@ -19,8 +19,48 @@ services:
       - "8080:8080" # 애플리케이션 포트 매핑
     environment:
       - SPRING_PROFILES_ACTIVE=dev # Spring Boot 프로필 설정
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
     depends_on:
       - mongodb # MongoDB 컨테이너가 먼저 실행되도록 설정
+      - kafka
+    networks:
+      - app-network
+
+  zookeeper:
+    # 사용할 이미지
+    image: bitnami/zookeeper:latest
+    # 컨테이너명 설정
+    container_name: zookeeper
+    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes  # 익명 접속 허용 -> 테스트 환경에서만
+      - ZOO_4LW_COMMANDS_WHITELIST=ruok,stat,conf,isro  # 필요한 명령어 추가
+    ports:
+      - "2181:2181"
+    networks:
+      - app-network
+
+  # 서비스 명
+  kafka:
+    # 사용할 이미지
+    image: bitnami/kafka:latest
+    # 컨테이너명 설정
+    container_name: kafka
+    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
+    ports:
+      - "9092:9092"
+    # 환경 변수 설정
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka  # Kafka 브로커의 호스트 이름
+#      bitnami/kafka 이미지는 KAFKA_CREATE_TOPICS 환경 변수를 기본적으로 지원 안함
+#      KAFKA_CREATE_TOPICS: "chat:10:3"    # 초기 토픽 생성 (토픽:파티션개수:복제본개수)
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181  # Zookeeper 연결 정보
+    # 볼륨 설정
+    volumes:
+      - /var/run/docker.sock
+    # 의존 관계 설정
+    depends_on:
+      - zookeeper
     networks:
       - app-network
 
@@ -28,4 +68,4 @@ volumes:
   mongodb-data: # MongoDB 데이터 영구 저장소
 
 networks:
-  app-network: # 두 컨테이너가 사용할 네트워크
+  app-network:

--- a/chat/src/main/java/chocoletter/chat/common/config/KafkaConsumerConfig.java
+++ b/chat/src/main/java/chocoletter/chat/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,59 @@
+package chocoletter.chat.common.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${kafka.consumer.group-id}")
+    private String consumerGroup;
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        // Batch Listener 활성화
+        factory.setBatchListener(true);
+
+        return factory;
+    }
+
+    private ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+
+        // Kafka 클러스터 주소 설정
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        // Deserializer 설정
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        // Consumer 그룹 설정
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
+
+        // Offsets 설정
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"); // 처음부터 읽기
+
+        // 토픽 자동 생성 비활성화
+        props.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+
+        // 자동 커밋 비활성화 (필요 시 활성화)
+        /* props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false); */
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/common/config/KafkaProducerConfig.java
+++ b/chat/src/main/java/chocoletter/chat/common/config/KafkaProducerConfig.java
@@ -1,0 +1,50 @@
+package chocoletter.chat.common.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    private final String[] acks = {"0", "1", "all"}; // ACK 설정 옵션
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(kafkaProducerFactory());
+    }
+
+    private ProducerFactory<String, String> kafkaProducerFactory() {
+        Map<String, Object> props = new HashMap<>();
+
+        // Kafka 클러스터 주소 설정
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        // Serializer 설정
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        // ACK 설정
+        // acks[1]: 브로커 한 대만 확인하면 성공으로 처리
+        // acks[2]: all은 리더와 복제본 모두가 확인할 때 성공으로 처리
+        props.put(ProducerConfig.ACKS_CONFIG, acks[1]);
+
+        // 추가 옵션
+        props.put(ProducerConfig.LINGER_MS_CONFIG, 5); // 메시지 배치 딜레이 (밀리초)
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384); // 배치 크기 (16KB)
+
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+}
+

--- a/chat/src/main/resources/application-dev.yml
+++ b/chat/src/main/resources/application-dev.yml
@@ -5,3 +5,8 @@ spring:
   data:
     mongodb:
       uri: mongodb://mongodb:27017/chatdb
+
+  kafka:
+    bootstrap-servers: kafka:9092
+    consumer:
+      group-id: chat-group


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #5 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 카프카 기본 세팅을 했습니다. 여러 옵션들이 있긴 한데 이건 추후 개발을 해가면서 감을 잡아야 할 것 같습니다.
- 일단 채팅방 별로 개별 토픽을 사용하기로 저번에 했던 것 같은데, 그렇게 되면 격리성과 확장성은 좋아지지만 불필요한 리소스를 사용하는 방식이 될 수도 있다는 우려가 있었습니다.
- 따라서 초기에는 단일 토픽과 파티션을 활용하는 방식으로 시작하여, 시스템이 성장하고 채팅방 수가 많아지면 채팅방 별 토픽 생성으로 전환하는 방식으로 진행하였습니다.
- 현재는 파티션을 10개로 두고, 브로커도 한 대만 사용하기 때문에 복제본은 의미가 없어 1로 설정합니다.
- bitnami/kafka 이미지는 KAFKA_CREATE_TOPICS 환경 변수를 기본적으로 지원 안하기 때문에 로컬에서 돌려볼 때, 아래 명령어를 수동으로 입력해주세요 !

```bash
docker exec -it kafka kafka-topics.sh --create --topic chat--bootstrap-server kafka:9092 --partitions 10 --replication-factor 1
```

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Reference

<!-- 참고한 코드의 출처를 작성해주세요 -->
