### PR TITLE
[FEAT] STOMP와 카프카 연결

### DIFF
--- a/chat/docker-compose.yml
+++ b/chat/docker-compose.yml
@@ -19,7 +19,8 @@ services:
       - "8080:8080" # 애플리케이션 포트 매핑
     environment:
       - SPRING_PROFILES_ACTIVE=dev # Spring Boot 프로필 설정
-      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092 # Kafka 브로커 연결 설정
+      - SPRING_DATA_MONGODB_URI=mongodb://mongodb:27017/chatdb # MongoDB 연결 설정
     depends_on:
       - mongodb # MongoDB 컨테이너가 먼저 실행되도록 설정
       - kafka
@@ -27,40 +28,28 @@ services:
       - app-network
 
   zookeeper:
-    # 사용할 이미지
     image: bitnami/zookeeper:latest
-    # 컨테이너명 설정
     container_name: zookeeper
-    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes  # 익명 접속 허용 -> 테스트 환경에서만
-      - ZOO_4LW_COMMANDS_WHITELIST=ruok,stat,conf,isro  # 필요한 명령어 추가
+      - ALLOW_ANONYMOUS_LOGIN=yes # 익명 접속 허용 (테스트 환경에서만)
+      - ZOO_4LW_COMMANDS_WHITELIST=ruok,stat,conf,isro # Zookeeper 명령어 허용
     ports:
-      - "2181:2181"
+      - "2181:2181" # Zookeeper 포트 매핑
     networks:
       - app-network
 
-  # 서비스 명
   kafka:
-    # 사용할 이미지
     image: bitnami/kafka:latest
-    # 컨테이너명 설정
     container_name: kafka
-    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
     ports:
-      - "9092:9092"
-    # 환경 변수 설정
+      - "9092:9092" # Kafka 브로커 포트 매핑
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: kafka  # Kafka 브로커의 호스트 이름
-#      bitnami/kafka 이미지는 KAFKA_CREATE_TOPICS 환경 변수를 기본적으로 지원 안함
-#      KAFKA_CREATE_TOPICS: "chat:10:3"    # 초기 토픽 생성 (토픽:파티션개수:복제본개수)
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181  # Zookeeper 연결 정보
-    # 볼륨 설정
-    volumes:
-      - /var/run/docker.sock
-    # 의존 관계 설정
+      KAFKA_BROKER_ID: 1
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092 # 컨테이너 내부에서 호스트 이름 사용
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181 # Zookeeper 연결 정보
     depends_on:
-      - zookeeper
+      - zookeeper # Zookeeper 컨테이너가 먼저 실행되도록 설정
     networks:
       - app-network
 
@@ -69,3 +58,4 @@ volumes:
 
 networks:
   app-network:
+    driver: bridge

--- a/chat/src/main/java/chocoletter/chat/api/chat/controller/ChatController.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/controller/ChatController.java
@@ -4,7 +4,10 @@ import chocoletter.chat.api.chat.domain.ChatMessage;
 import chocoletter.chat.api.chat.dto.request.ChatMessageRequestDto;
 import chocoletter.chat.api.chat.dto.response.ChatMessageResponseDto;
 import chocoletter.chat.api.chat.repository.ChatMessageRepository;
+import chocoletter.chat.api.chat.service.ChatMessageProducer;
 import chocoletter.chat.api.chat.service.ChatMessageService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -16,25 +19,17 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class ChatController {
 
-    private final SimpMessagingTemplate messagingTemplate;
-    private final ChatMessageService chatMessageService;
+    private final ChatMessageProducer chatMessageProducer;
 
     @MessageMapping("/send")
     public void sendMessage(ChatMessageRequestDto chatMessageRequestDto) {
-        // 어느 방(어느 채널)로 가야되는 메시지인지 설정하는 부분
-        String topic = "/topic/" + chatMessageRequestDto.getRoomId();
-        // RequestDto를 받아서 ResponseDto로 만들어서 전달하는 부분(실시간이 중요하다고 생각해서 일단 상대한테 보낸 뒤에 저장하는 로직으로 짬)
-        messagingTemplate.convertAndSend(topic, ChatMessageResponseDto.builder()
-                .senderId(chatMessageRequestDto.getSenderId())
-                .content(chatMessageRequestDto.getContent())
-                .read(false)
-                .createdAt(String.valueOf(LocalDateTime.now()))
-                .build());
-        // 채팅이 날아온 걸 DB에 저장하는 부분
-        chatMessageService.saveChatMessage(ChatMessage.builder()
-                .senderId(chatMessageRequestDto.getSenderId())
-                .roomId(chatMessageRequestDto.getRoomId())
-                .content(chatMessageRequestDto.getContent())
-                .build());
+        // Kafka로 메시지 전송
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String message = objectMapper.writeValueAsString(chatMessageRequestDto);
+            chatMessageProducer.sendMessage(chatMessageRequestDto.getRoomId(), message); // Kafka topic으로 전송
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize message", e);
+        }
     }
 }

--- a/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageConsumer.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageConsumer.java
@@ -1,0 +1,50 @@
+package chocoletter.chat.api.chat.service;
+
+import chocoletter.chat.api.chat.domain.ChatMessage;
+import chocoletter.chat.api.chat.dto.request.ChatMessageRequestDto;
+import chocoletter.chat.api.chat.dto.response.ChatMessageResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageConsumer {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatMessageService chatMessageService;
+
+    @KafkaListener(topics = "${kafka.topic.chat}", groupId = "${kafka.consumer.group-id}")
+    public void consumeMessage(String message) {
+        // 메시지를 WebSocket으로 전송
+        ChatMessageRequestDto chatMessageRequestDto = parseMessage(message);
+        String topic = "/topic/" + chatMessageRequestDto.getRoomId();
+        messagingTemplate.convertAndSend(topic, ChatMessageResponseDto.builder()
+                .senderId(chatMessageRequestDto.getSenderId())
+                .content(chatMessageRequestDto.getContent())
+                .read(false)
+                .createdAt(String.valueOf(LocalDateTime.now()))
+                .build());
+
+        // MongoDB에 메시지 저장
+        chatMessageService.saveChatMessage(ChatMessage.builder()
+                .senderId(chatMessageRequestDto.getSenderId())
+                .roomId(chatMessageRequestDto.getRoomId())
+                .content(chatMessageRequestDto.getContent())
+                .build());
+    }
+
+    private ChatMessageRequestDto parseMessage(String message) {
+        // JSON 문자열을 DTO로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readValue(message, ChatMessageRequestDto.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse message", e);
+        }
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageProducer.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageProducer.java
@@ -1,0 +1,16 @@
+package chocoletter.chat.api.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendMessage(String roomId, String message) {
+        kafkaTemplate.send("chat", roomId, message); // Key로 roomId 설정
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageService.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
+
     public void saveChatMessage(ChatMessage chatMessage) {
         chatMessageRepository.save(chatMessage);
     }

--- a/chat/src/main/java/chocoletter/chat/common/config/KafkaConsumerConfig.java
+++ b/chat/src/main/java/chocoletter/chat/common/config/KafkaConsumerConfig.java
@@ -25,10 +25,9 @@ public class KafkaConsumerConfig {
     public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
-
-        // Batch Listener 활성화
-        factory.setBatchListener(true);
-
+        factory.setBatchListener(false); // 메시지 하나씩 처리
+        // Consumer를 5개로 늘리기
+        factory.setConcurrency(5);
         return factory;
     }
 

--- a/chat/src/main/resources/application-dev.yml
+++ b/chat/src/main/resources/application-dev.yml
@@ -4,9 +4,20 @@ spring:
       on-profile: dev
   data:
     mongodb:
-      uri: mongodb://mongodb:27017/chatdb
+      uri: mongodb://mongodb:27017/chatdb # MongoDB 컨테이너 이름으로 연결
 
-  kafka:
-    bootstrap-servers: kafka:9092
-    consumer:
-      group-id: chat-group
+kafka:
+  bootstrap-servers: kafka:9092 # Kafka 컨테이너 이름으로 연결
+  topic:
+    chat: chat # Kafka 토픽 이름
+  consumer:
+    group-id: chat-group
+    auto-offset-reset: earliest # 처음 시작할 때 오프셋을 처음부터 읽도록 설정
+  producer:
+    key-serializer: org.apache.kafka.common.serialization.StringSerializer
+    value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+logging:
+  level:
+    org.apache.kafka.clients.producer.ProducerConfig: WARN
+    org.apache.kafka.clients.consumer.ConsumerConfig: WARN

--- a/chat/src/main/resources/application.yml
+++ b/chat/src/main/resources/application.yml
@@ -1,4 +1,3 @@
 spring:
-  config:
-    activate:
-      on-profile: local
+  profiles:
+    active: local # 기본은 local


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #9 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 기존 STOMP 코드와 카프카 연결 했습니다.
- STOMP에서 기본적으로 제공하는 인메모리 브로커 대신 카프카 브로커로 메세지 보내고, 컨슈머가 메세지 받아서 웹소켓에 보내고 history에 저장하는 형식으로 구현했습니다.
- 일단은 되게만 해본거라 추후 코드도 좀 리팩토링하고 카프카 관련 세팅 값들 조정할 것 같습니다 !

<img width="1477" alt="image" src="https://github.com/user-attachments/assets/72612bcb-cc1a-4084-959b-e6bc54ef3645" />

<img src="https://github.com/user-attachments/assets/2265b530-9639-48c2-a06b-70ebdd9115fd" alt="image" width="300"/>

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- 참고 ! 도커로 몽고디비랑 카프카, 주키퍼만 띄운 상태에서 스프링 부트는 인텔리제이로 돌려보고 싶을 때는 yml 파일에서 컨테이너 이름 쓰지 않고 localhost로 해주시면 됩니다. 
- 그리고 그렇게 되면 도커로 kafka 띄울 때, docker-compse 파일 보시면 `KAFKA_ADVERTISED_LISTENERS` 값이 있는데 거기도 컨테이너 이름 대신 localhost로 바꿔주신 다음 띄워서 테스트 해야 합니다 !
- 이 과정이 좀 번거로워서 제가 좀더 알아보고 해결 방안을 찾던지, 파일을 분리하던지 해보겠습니다..!

## 📬 Reference

<!-- 참고한 코드의 출처를 작성해주세요 -->
