### PR TITLE
[FEAT] 채팅 읽음 처리 기능 구현

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -28,6 +28,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation "org.springframework.kafka:spring-kafka"
+
+	// jwt 의존성 추가
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/chat/src/main/java/chocoletter/chat/api/chat/controller/ChatRestController.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/controller/ChatRestController.java
@@ -3,10 +3,12 @@ package chocoletter.chat.api.chat.controller;
 import chocoletter.chat.api.chat.dto.response.ChatMessagesResponseDto;
 import chocoletter.chat.api.chat.dto.response.LastChatMessageResponseDto;
 import chocoletter.chat.api.chat.service.ChatMessageService;
+import chocoletter.chat.api.chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/chat")
 public class ChatRestController {
     private final ChatMessageService chatMessageService;
+    private final ChatRoomService chatRoomService;
 
     @GetMapping("/{roomId}/all")
     public ResponseEntity<?> findChatMessages(@PathVariable("roomId") String roomId,
@@ -27,8 +30,17 @@ public class ChatRestController {
 
     @GetMapping("/{roomId}/{memberId}/last")
     public ResponseEntity<?> findLastChatMessage(@PathVariable("roomId") String roomId,
-                                                 @PathVariable("memberId") Long memberId) {
+                                                 @PathVariable("memberId") String memberId) {
         LastChatMessageResponseDto lastChatMessage = chatMessageService.findLastChatMessage(roomId, memberId);
         return ResponseEntity.ok(lastChatMessage);
+    }
+
+    // 채팅방 접속 끊기
+    @PostMapping("/{roomId}/{memberId}/disconnect")
+    public ResponseEntity<?> disconnectChat(@PathVariable("roomId") String roomId,
+                                            @PathVariable("memberId") String memberId) {
+
+        chatRoomService.disconnectChatRoom(roomId, memberId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/chat/src/main/java/chocoletter/chat/api/chat/controller/ChatWebSocketController.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/controller/ChatWebSocketController.java
@@ -2,6 +2,8 @@ package chocoletter.chat.api.chat.controller;
 
 import chocoletter.chat.api.chat.dto.request.ChatMessageRequestDto;
 import chocoletter.chat.api.chat.service.ChatMessageProducer;
+import chocoletter.chat.common.exception.ErrorMessage;
+import chocoletter.chat.common.exception.InternalServerException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +24,7 @@ public class ChatWebSocketController {
             String message = objectMapper.writeValueAsString(chatMessageRequestDto);
             chatMessageProducer.sendMessage(chatMessageRequestDto.getRoomId(), message); // Kafka topic으로 전송
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to serialize message", e);
+            throw new InternalServerException(ErrorMessage.ERR_SERIALIZE_MESSAGE);
         }
     }
 }

--- a/chat/src/main/java/chocoletter/chat/api/chat/domain/ChatMessage.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/domain/ChatMessage.java
@@ -14,19 +14,19 @@ public class ChatMessage {
     @Id
     private String id;
     private String roomId;
-    private Long senderId;
+    private String senderId;
     private String senderName;
     private String content;
     private LocalDateTime createdAt;
     private Boolean isRead;
 
     @Builder
-    public ChatMessage(String roomId, Long senderId, String senderName, String content) {
+    public ChatMessage(String roomId, String senderId, String senderName, String content, Boolean isRead) {
         this.roomId = roomId;
         this.senderId = senderId;
         this.senderName = senderName;
         this.content = content;
         this.createdAt = LocalDateTime.now();
-        this.isRead = false;
+        this.isRead = isRead;
     }
 }

--- a/chat/src/main/java/chocoletter/chat/api/chat/domain/MessageType.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/domain/MessageType.java
@@ -1,0 +1,6 @@
+package chocoletter.chat.api.chat.domain;
+
+public enum MessageType {
+    CHAT,
+    READ_STATUS
+}

--- a/chat/src/main/java/chocoletter/chat/api/chat/dto/request/ChatMessageRequestDto.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/dto/request/ChatMessageRequestDto.java
@@ -1,11 +1,13 @@
 package chocoletter.chat.api.chat.dto.request;
 
+import chocoletter.chat.api.chat.domain.MessageType;
 import lombok.Getter;
 
 @Getter
 public class ChatMessageRequestDto {
+    private MessageType messageType;
     private String roomId;
-    private Long senderId;
+    private String senderId;
     private String senderName;
     private String content;
 }

--- a/chat/src/main/java/chocoletter/chat/api/chat/dto/response/ChatMessageResponseDto.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/dto/response/ChatMessageResponseDto.java
@@ -2,12 +2,15 @@ package chocoletter.chat.api.chat.dto.response;
 
 
 import chocoletter.chat.api.chat.domain.ChatMessage;
+import chocoletter.chat.api.chat.domain.MessageType;
 import lombok.Builder;
 
 @Builder
-public record ChatMessageResponseDto(Long senderId, String senderName, String content, String createdAt, Boolean isRead) {
-    public static ChatMessageResponseDto of(ChatMessage chatMessage) {
+public record ChatMessageResponseDto(MessageType messageType, Long senderId, String senderName,
+                                     String content, String createdAt, Boolean isRead) {
+    public static ChatMessageResponseDto of(MessageType messageType, ChatMessage chatMessage) {
         return ChatMessageResponseDto.builder()
+                .messageType(messageType)
                 .senderId(chatMessage.getSenderId())
                 .senderName(chatMessage.getSenderName())
                 .content(chatMessage.getContent())

--- a/chat/src/main/java/chocoletter/chat/api/chat/dto/response/ChatMessageResponseDto.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/dto/response/ChatMessageResponseDto.java
@@ -6,11 +6,12 @@ import chocoletter.chat.api.chat.domain.MessageType;
 import lombok.Builder;
 
 @Builder
-public record ChatMessageResponseDto(MessageType messageType, Long senderId, String senderName,
+public record ChatMessageResponseDto(MessageType messageType, String roomId, String senderId, String senderName,
                                      String content, String createdAt, Boolean isRead) {
     public static ChatMessageResponseDto of(MessageType messageType, ChatMessage chatMessage) {
         return ChatMessageResponseDto.builder()
                 .messageType(messageType)
+                .roomId(chatMessage.getRoomId())
                 .senderId(chatMessage.getSenderId())
                 .senderName(chatMessage.getSenderName())
                 .content(chatMessage.getContent())

--- a/chat/src/main/java/chocoletter/chat/api/chat/repository/ChatMessageRepository.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/repository/ChatMessageRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,5 +21,9 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
                     "count: { $sum: { $cond: [{ $and: [ { $ne: ['$senderId', ?1] }, { $eq: ['$isRead', false] } ] }, 1, 0] } }, " +
                     "message: { $last: '$content' } } }"
     })
-    LastChatMessageResponseDto findUnReadCountAndLastMessage(String roomId, Long memberId);
+    LastChatMessageResponseDto findUnReadCountAndLastMessage(String roomId, String memberId);
+
+    @Query("{ 'roomId': ?0}")
+    @Update("{ '$set': { 'isRead': true } }")
+    void readAllUnreadMessages(String roomId);
 }

--- a/chat/src/main/java/chocoletter/chat/api/chat/repository/InMemoryChatRoomRepository.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/repository/InMemoryChatRoomRepository.java
@@ -1,0 +1,32 @@
+package chocoletter.chat.api.chat.repository;
+
+import lombok.Getter;
+import org.springframework.stereotype.Repository;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+@Getter
+public class InMemoryChatRoomRepository {
+
+    private final Map<String, List<String>> chatRooms = new ConcurrentHashMap<>(); // key : roomId, value : 멤버 id 리스트
+
+    // 특정 roomId에 접속한 멤버 리스트 가져오기
+    public List<String> findOnlineMembers(String roomId) {
+        return chatRooms.getOrDefault(roomId, new ArrayList<>());
+    }
+
+    // 채팅방 저장 (입장 내역 추가)
+    public void save(String roomId, String memberId) {
+        chatRooms.computeIfAbsent(roomId, k -> new ArrayList<>()).add(memberId);
+    }
+
+    // 채팅방 삭제 (퇴장 시)
+    public void remove(String roomId, String memberId) {
+        chatRooms.computeIfPresent(roomId, (key, rooms) -> {
+            rooms.removeIf(id -> Objects.equals(id, memberId));
+            return rooms.isEmpty() ? null : rooms;
+        });
+    }
+}
+

--- a/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageConsumer.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageConsumer.java
@@ -1,8 +1,11 @@
 package chocoletter.chat.api.chat.service;
 
 import chocoletter.chat.api.chat.domain.ChatMessage;
+import chocoletter.chat.api.chat.domain.MessageType;
 import chocoletter.chat.api.chat.dto.request.ChatMessageRequestDto;
 import chocoletter.chat.api.chat.dto.response.ChatMessageResponseDto;
+import chocoletter.chat.common.exception.ErrorMessage;
+import chocoletter.chat.common.exception.InternalServerException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
@@ -17,36 +20,56 @@ public class ChatMessageConsumer {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final ChatMessageService chatMessageService;
+    private final ChatRoomService chatRoomService;
 
     @KafkaListener(topics = "${spring.kafka.topic.chat}", groupId = "${spring.kafka.consumer.group-id}")
     public void consumeMessage(String message) {
         // 메시지를 WebSocket으로 전송
-        ChatMessageRequestDto chatMessageRequestDto = parseMessage(message);
-        String topic = "/topic/" + chatMessageRequestDto.getRoomId();
+        ChatMessageResponseDto chatMessageResponseDto = parseMessage(message);
+        String topic = "/topic/" + chatMessageResponseDto.roomId();
+
+        if (chatMessageResponseDto.messageType().equals(MessageType.READ_STATUS)) {
+            ChatMessageResponseDto result = ChatMessageResponseDto.builder()
+                    .messageType(chatMessageResponseDto.messageType())
+                    .senderId(chatMessageResponseDto.senderId())
+                    .senderName(chatMessageResponseDto.senderName())
+                    .content(chatMessageResponseDto.content())
+                    .isRead(false)
+                    .createdAt(String.valueOf(LocalDateTime.now()))
+                    .build();
+            messagingTemplate.convertAndSend(topic, result);
+            return;
+        }
+
+        // 현재 채팅방에 접속중인 인원이 있는지 확인
+        boolean isAllConnected = chatRoomService.isAllConnected(chatMessageResponseDto.roomId());
+
         messagingTemplate.convertAndSend(topic, ChatMessageResponseDto.builder()
-                .senderId(chatMessageRequestDto.getSenderId())
-                .senderName(chatMessageRequestDto.getSenderName())
-                .content(chatMessageRequestDto.getContent())
-                .isRead(false)
+                .messageType(chatMessageResponseDto.messageType())
+                .senderId(chatMessageResponseDto.senderId())
+                .senderName(chatMessageResponseDto.senderName())
+                .content(chatMessageResponseDto.content())
+                .isRead(isAllConnected)
                 .createdAt(String.valueOf(LocalDateTime.now()))
                 .build());
 
         // MongoDB에 메시지 저장
         chatMessageService.saveChatMessage(ChatMessage.builder()
-                .senderId(chatMessageRequestDto.getSenderId())
-                .senderName(chatMessageRequestDto.getSenderName())
-                .roomId(chatMessageRequestDto.getRoomId())
-                .content(chatMessageRequestDto.getContent())
+                .senderId(chatMessageResponseDto.senderId())
+                .senderName(chatMessageResponseDto.senderName())
+                .roomId(chatMessageResponseDto.roomId())
+                .content(chatMessageResponseDto.content())
+                .isRead(isAllConnected)
                 .build());
     }
 
-    private ChatMessageRequestDto parseMessage(String message) {
+    private ChatMessageResponseDto parseMessage(String message) {
         // JSON 문자열을 DTO로 변환
         ObjectMapper objectMapper = new ObjectMapper();
         try {
-            return objectMapper.readValue(message, ChatMessageRequestDto.class);
+            return objectMapper.readValue(message, ChatMessageResponseDto.class);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to parse message", e);
+            throw new InternalServerException(ErrorMessage.ERR_PARSING_MESSAGE);
         }
     }
 }

--- a/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageService.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageService.java
@@ -1,6 +1,7 @@
 package chocoletter.chat.api.chat.service;
 
 import chocoletter.chat.api.chat.domain.ChatMessage;
+import chocoletter.chat.api.chat.domain.MessageType;
 import chocoletter.chat.api.chat.dto.response.ChatMessageResponseDto;
 import chocoletter.chat.api.chat.dto.response.ChatMessagesResponseDto;
 import chocoletter.chat.api.chat.dto.response.LastChatMessageResponseDto;
@@ -25,11 +26,11 @@ public class ChatMessageService {
         Pageable pageable = PageRequest.of(page, size);
         List<ChatMessageResponseDto> chatMessages = chatMessageRepository.findChatMessages(roomId, pageable)
                 .stream()
-                .map(ChatMessageResponseDto::of)
+                .map(chatMessage -> ChatMessageResponseDto.of(MessageType.CHAT, chatMessage))
                 .toList();
         return ChatMessagesResponseDto.of(chatMessages);
-
     }
+
 
     public LastChatMessageResponseDto findLastChatMessage(String roomId, Long memberId) {
         return chatMessageRepository.findUnReadCountAndLastMessage(roomId, memberId);

--- a/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageService.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/service/ChatMessageService.java
@@ -6,17 +6,25 @@ import chocoletter.chat.api.chat.dto.response.ChatMessageResponseDto;
 import chocoletter.chat.api.chat.dto.response.ChatMessagesResponseDto;
 import chocoletter.chat.api.chat.dto.response.LastChatMessageResponseDto;
 import chocoletter.chat.api.chat.repository.ChatMessageRepository;
+import chocoletter.chat.common.exception.ErrorMessage;
+import chocoletter.chat.common.exception.InternalServerException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.KafkaProducer;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageProducer chatMessageProducer;
 
     public void saveChatMessage(ChatMessage chatMessage) {
         chatMessageRepository.save(chatMessage);
@@ -31,8 +39,27 @@ public class ChatMessageService {
         return ChatMessagesResponseDto.of(chatMessages);
     }
 
-
-    public LastChatMessageResponseDto findLastChatMessage(String roomId, Long memberId) {
+    public LastChatMessageResponseDto findLastChatMessage(String roomId, String memberId) {
         return chatMessageRepository.findUnReadCountAndLastMessage(roomId, memberId);
+    }
+
+    @Transactional
+    public void readAllUnreadMessages(String roomId) {
+        chatMessageRepository.readAllUnreadMessages(roomId);
+    }
+
+    public void noticeReadStatus(String roomId) {
+        ChatMessageResponseDto chatMessageResponseDto = ChatMessageResponseDto.builder()
+                .roomId(roomId)
+                .messageType(MessageType.READ_STATUS)
+                .content("채팅 메세지의 읽음 상태가 변경되었습니다.")
+                .build();
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String message = objectMapper.writeValueAsString(chatMessageResponseDto);
+            chatMessageProducer.sendMessage(roomId, message); // Kafka topic으로 전송
+        } catch (JsonProcessingException e) {
+            throw new InternalServerException(ErrorMessage.ERR_SERIALIZE_MESSAGE);
+        }
     }
 }

--- a/chat/src/main/java/chocoletter/chat/api/chat/service/ChatRoomService.java
+++ b/chat/src/main/java/chocoletter/chat/api/chat/service/ChatRoomService.java
@@ -1,0 +1,33 @@
+package chocoletter.chat.api.chat.service;
+
+import chocoletter.chat.api.chat.repository.InMemoryChatRoomRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final InMemoryChatRoomRepository inMemoryChatRoomRepository;
+
+    @Transactional
+    public void connectChatRoom(String roomId, String memberId) {
+        inMemoryChatRoomRepository.save(roomId, memberId);
+    }
+
+    @Transactional
+    public void disconnectChatRoom(String roomId, String memberId) {
+        inMemoryChatRoomRepository.remove(roomId, memberId);
+    }
+
+    public boolean isAllConnected(String roomId) {
+        List<String> connectedMemberList = inMemoryChatRoomRepository.findOnlineMembers(roomId);
+        return connectedMemberList.size() == 2;
+    }
+
+}

--- a/chat/src/main/java/chocoletter/chat/common/config/WebConfig.java
+++ b/chat/src/main/java/chocoletter/chat/common/config/WebConfig.java
@@ -1,0 +1,25 @@
+package chocoletter.chat.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**") // 모든 경로에 대해 CORS 설정 적용
+                        .allowedOrigins("http://localhost:5173") // 허용할 도메인 (특정 도메인만 허용)
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
+                        .allowedHeaders("*") // 모든 헤더 허용
+                        .allowCredentials(true) // 쿠키 및 인증 정보 포함 허용 (withCredentials: true)
+                        .maxAge(3600); // pre-flight 요청 캐시 시간 (1시간)
+            }
+        };
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/common/config/WebSocketConfig.java
+++ b/chat/src/main/java/chocoletter/chat/common/config/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package chocoletter.chat.common.config;
 
+import chocoletter.chat.common.interceptor.StompInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,11 +11,20 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final StompInterceptor stompInterceptor;
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic"); // 브로커가 메시지 보내는 곳
         registry.setApplicationDestinationPrefixes("/app"); // 클라이언트가 메시지를 보낼 곳
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // stompHandler를 인터셉터로 등록하여 STOMP 메시지 핸들링을 수행
+        registration.interceptors(stompInterceptor);
     }
 
     @Override

--- a/chat/src/main/java/chocoletter/chat/common/exception/BadRequestException.java
+++ b/chat/src/main/java/chocoletter/chat/common/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package chocoletter.chat.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends ChocoLetterException {
+    public BadRequestException(ErrorMessage errorMessage) {
+        super(HttpStatus.BAD_REQUEST, errorMessage);
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/common/exception/ChocoLetterException.java
+++ b/chat/src/main/java/chocoletter/chat/common/exception/ChocoLetterException.java
@@ -1,0 +1,16 @@
+package chocoletter.chat.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ChocoLetterException extends RuntimeException {
+    HttpStatus status;
+    ErrorMessage errorMessage;
+
+    public ChocoLetterException(HttpStatus status, ErrorMessage errorMessage) {
+        super(errorMessage.toString());
+        this.status = status;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/common/exception/ErrorMessage.java
+++ b/chat/src/main/java/chocoletter/chat/common/exception/ErrorMessage.java
@@ -1,0 +1,27 @@
+package chocoletter.chat.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorMessage {
+
+    /**
+     * 400 Bad Request
+     */
+    ERR_EMPTY_TOKEN,
+    ERR_INVALID_SUBSCRIBE_DESTINATION,
+
+    /**
+     * 401 Unauthorized
+     */
+    ERR_ACCESS_TOKEN_EXPIRED,
+    ERR_INVALID_TOKEN,
+
+    /**
+     * 500 Internal Server Exception
+     */
+    ERR_SERIALIZE_MESSAGE,
+    ERR_PARSING_MESSAGE,
+    ERR_ENCRYPT_FAIL;
+
+}

--- a/chat/src/main/java/chocoletter/chat/common/exception/FailResponse.java
+++ b/chat/src/main/java/chocoletter/chat/common/exception/FailResponse.java
@@ -1,0 +1,22 @@
+package chocoletter.chat.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.FieldError;
+
+@Getter
+@Builder
+public class FailResponse {
+    private final int status;
+    private final String errorMessage;
+
+    public static FailResponse fail(int status, ErrorMessage errorMessage) {
+        return FailResponse.builder()
+                .status(status)
+                .errorMessage(errorMessage.toString())
+                .build();
+    }
+
+}

--- a/chat/src/main/java/chocoletter/chat/common/exception/ForbiddenException.java
+++ b/chat/src/main/java/chocoletter/chat/common/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package chocoletter.chat.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends ChocoLetterException {
+    public ForbiddenException(ErrorMessage errorMessage) {
+        super(HttpStatus.FORBIDDEN, errorMessage);
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/common/exception/InternalServerException.java
+++ b/chat/src/main/java/chocoletter/chat/common/exception/InternalServerException.java
@@ -1,0 +1,9 @@
+package chocoletter.chat.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InternalServerException extends ChocoLetterException {
+    public InternalServerException(ErrorMessage errorMessage) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, errorMessage);
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/common/exception/UnAuthorizedException.java
+++ b/chat/src/main/java/chocoletter/chat/common/exception/UnAuthorizedException.java
@@ -1,0 +1,9 @@
+package chocoletter.chat.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnAuthorizedException extends ChocoLetterException {
+    public UnAuthorizedException(ErrorMessage errorMessage) {
+        super(HttpStatus.UNAUTHORIZED, errorMessage);
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/common/interceptor/StompInterceptor.java
+++ b/chat/src/main/java/chocoletter/chat/common/interceptor/StompInterceptor.java
@@ -1,0 +1,110 @@
+package chocoletter.chat.common.interceptor;
+
+import chocoletter.chat.api.chat.service.ChatMessageService;
+import chocoletter.chat.api.chat.service.ChatRoomService;
+import chocoletter.chat.common.exception.BadRequestException;
+import chocoletter.chat.common.exception.ErrorMessage;
+import chocoletter.chat.common.exception.InternalServerException;
+import chocoletter.chat.common.exception.UnAuthorizedException;
+import chocoletter.chat.common.util.IdEncryptionUtil;
+import chocoletter.chat.common.util.JwtUtil;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompInterceptor implements ChannelInterceptor {
+
+    private final JwtUtil jwtUtil;
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+    private final IdEncryptionUtil idEncryptionUtil;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        // DISCONNECT 커맨드일 경우 토큰 검증 skip
+        if (accessor.getCommand() == StompCommand.DISCONNECT) {
+            return message;
+        }
+        String memberId;
+        try {
+            Long beforeId = verifyAccessToken(getAccessToken(accessor));
+            memberId = idEncryptionUtil.encrypt(beforeId);
+        } catch (Exception e) {
+            throw new InternalServerException(ErrorMessage.ERR_ENCRYPT_FAIL);
+        }
+        log.info("StompAccessor = {}", accessor);
+        handleMessage(accessor.getCommand(), accessor, memberId);
+        return message;
+    }
+
+    private void handleMessage(StompCommand stompCommand, StompHeaderAccessor accessor, String memberId) {
+        switch (stompCommand) {
+            case CONNECT: // 웹소켓 연결할 때
+                break;
+            case SUBSCRIBE: // 채널 구독할 때 (우리의 경우 채팅방을 접속할 때)
+                connectToChatRoom(accessor, memberId);
+                break;
+            case SEND: // 메세지 전송할 때
+                break;
+        }
+    }
+
+    private void connectToChatRoom(StompHeaderAccessor accessor, String memberId) {
+        // 채팅방 id 파싱
+        String roomId = getChatRoomId(accessor);
+        // 채팅방 입장 처리 -> Redis에 입장 내역 저장
+        chatRoomService.connectChatRoom(roomId, memberId);
+        // 읽지 않은 채팅을 전부 읽음 처리
+        chatMessageService.readAllUnreadMessages(roomId);
+        // 현재 채팅방에 접속중인 인원이 있는지 확인
+        boolean isAllConnected = chatRoomService.isAllConnected(roomId);
+
+        if (isAllConnected) {
+            chatMessageService.noticeReadStatus(roomId);
+        }
+    }
+
+    private String getChatRoomId(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+
+        Pattern pattern = Pattern.compile("/topic/([^/]+)");
+        Matcher matcher = pattern.matcher(destination);
+
+        if (matcher.find()) {
+            log.info("Parsing roomId: {}", matcher.group(1));
+            return matcher.group(1);
+        } else {
+            log.error("Invalid destination: {}", destination);
+            throw new BadRequestException(ErrorMessage.ERR_INVALID_SUBSCRIBE_DESTINATION);
+        }
+    }
+
+
+    private String getAccessToken(StompHeaderAccessor accessor) {
+        String header = accessor.getFirstNativeHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            throw new BadRequestException(ErrorMessage.ERR_EMPTY_TOKEN);
+        } else {
+            return header.split(" ")[1];
+        }
+    }
+
+    private Long verifyAccessToken(String accessToken) {
+        if (!jwtUtil.validateToken(accessToken)) {
+            throw new UnAuthorizedException(ErrorMessage.ERR_ACCESS_TOKEN_EXPIRED);
+        }
+        return jwtUtil.getIdFromToken(accessToken);
+    }
+
+}

--- a/chat/src/main/java/chocoletter/chat/common/util/IdEncryptionUtil.java
+++ b/chat/src/main/java/chocoletter/chat/common/util/IdEncryptionUtil.java
@@ -1,0 +1,37 @@
+package chocoletter.chat.common.util;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IdEncryptionUtil {
+
+    private static final String ALGORITHM = "AES";
+
+    @Value("${encrypt.secret-key}")
+    private String secretKey;
+
+    public String encrypt(Long value) throws Exception {
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
+        byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(value).array();
+        byte[] encryptedData = cipher.doFinal(valueBytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(encryptedData);
+    }
+
+    public Long decrypt(String encryptedData) throws Exception {
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
+        byte[] decodedData = Base64.getUrlDecoder().decode(encryptedData);
+        byte[] decryptedBytes = cipher.doFinal(decodedData);
+        return ByteBuffer.wrap(decryptedBytes).getLong();
+    }
+}

--- a/chat/src/main/java/chocoletter/chat/common/util/JwtUtil.java
+++ b/chat/src/main/java/chocoletter/chat/common/util/JwtUtil.java
@@ -1,0 +1,37 @@
+package chocoletter.chat.common.util;
+
+import chocoletter.chat.common.exception.ErrorMessage;
+import chocoletter.chat.common.exception.UnAuthorizedException;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.*;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getIdFromToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return Long.parseLong(claims.getSubject());
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new UnAuthorizedException(ErrorMessage.ERR_INVALID_TOKEN);
+        }
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- closed #20 

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 채팅 읽음 처리 기능을 구현하였습니다.
- 채팅방 접속을 끊는 DISCONNECT에서는 header를 담아서 보내지 못한다고 해서, 해당 부분은 HTTP 통신으로 요청 받도록 구현하였습니다.
- 리팩토링은 추후 진행하겠습니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Reference

<!-- 참고한 코드의 출처를 작성해주세요 -->
